### PR TITLE
Update gopher64 module

### DIFF
--- a/io.github.gopher64.gopher64.metainfo.xml
+++ b/io.github.gopher64.gopher64.metainfo.xml
@@ -43,8 +43,11 @@
     <control>gamepad</control>
   </supports>
   <releases>
-   <release version="v1.1.20" date="2026-05-07">
+   <release version="v1.1.22" date="2026-05-28">
       <description></description>
+   </release>
+   <release version="v1.1.20" date="2026-05-07">
+      <description/>
    </release>
    <release version="v1.1.19" date="2026-04-25">
       <description/>

--- a/io.github.gopher64.gopher64.yaml
+++ b/io.github.gopher64.gopher64.yaml
@@ -23,8 +23,8 @@ modules:
       - install -D io.github.gopher64.gopher64.metainfo.xml -t /app/share/metainfo
     sources:
       - type: file
-        url: https://github.com/gopher64/gopher64/releases/download/v1.1.20/gopher64-linux-x86_64
-        sha256: 1235cd10974747115415f7c7852d3b015ab8224b339030a2f210495a4537a065
+        url: https://github.com/gopher64/gopher64/releases/download/v1.1.22/gopher64-linux-x86_64
+        sha256: 206a4074a1859f36ca9f3ffba7217baa679b28368be769936e3f64858b5e8c6b
         only-arches:
           - x86_64
         x-checker-data:
@@ -34,8 +34,8 @@ modules:
           version-query: .tag_name
           url-query: .assets[] | select(.name|contains("linux-x86_64")) | .browser_download_url
       - type: file
-        url: https://github.com/gopher64/gopher64/releases/download/v1.1.20/gopher64-linux-aarch64
-        sha256: 40b37126de0778b8223d0f07ff68f59499ede4933e016c6c2606c936f7b11703
+        url: https://github.com/gopher64/gopher64/releases/download/v1.1.22/gopher64-linux-aarch64
+        sha256: 238223062042b88ed3649dc85d67fc4b47ee66f8b0358680031b3f455cfbe996
         only-arches:
           - aarch64
         x-checker-data:


### PR DESCRIPTION
gopher64: Update gopher64-linux-x86_64 to v1.1.22
gopher64: Update gopher64-linux-aarch64 to v1.1.22