### PR TITLE
Update gopher64 module

### DIFF
--- a/io.github.gopher64.gopher64.metainfo.xml
+++ b/io.github.gopher64.gopher64.metainfo.xml
@@ -43,8 +43,11 @@
     <control>gamepad</control>
   </supports>
   <releases>
-   <release version="v1.1.26" date="2026-06-14">
+   <release version="v1.1.28" date="2026-06-16">
       <description></description>
+   </release>
+   <release version="v1.1.26" date="2026-06-14">
+      <description/>
    </release>
    <release version="v1.1.24" date="2026-06-09">
       <description/>

--- a/io.github.gopher64.gopher64.yaml
+++ b/io.github.gopher64.gopher64.yaml
@@ -23,8 +23,8 @@ modules:
       - install -D io.github.gopher64.gopher64.metainfo.xml -t /app/share/metainfo
     sources:
       - type: file
-        url: https://github.com/gopher64/gopher64/releases/download/v1.1.26/gopher64-linux-x86_64
-        sha256: a753a97846a59316fd9c7b44444246b17c5b30e234843b4ded6c2e93e7380c24
+        url: https://github.com/gopher64/gopher64/releases/download/v1.1.28/gopher64-linux-x86_64
+        sha256: 3fbf4a4dd85db2f03c9245e47a6e6cd3c71eebb36191f7fc8ed63763e0aa477c
         only-arches:
           - x86_64
         x-checker-data:
@@ -34,8 +34,8 @@ modules:
           version-query: .tag_name
           url-query: .assets[] | select(.name|contains("linux-x86_64")) | .browser_download_url
       - type: file
-        url: https://github.com/gopher64/gopher64/releases/download/v1.1.26/gopher64-linux-aarch64
-        sha256: 913cb20027c04811eacd35fed9cc28897f7022edd9a8e46e1e6ae6e2f3dc9cfe
+        url: https://github.com/gopher64/gopher64/releases/download/v1.1.28/gopher64-linux-aarch64
+        sha256: 69a4fa61b489857efd5ce57b3f5663f2a41b1f2139511a94e9ebaa0b026e1cf5
         only-arches:
           - aarch64
         x-checker-data:


### PR DESCRIPTION
gopher64: Update gopher64-linux-x86_64 to v1.1.28
gopher64: Update gopher64-linux-aarch64 to v1.1.28